### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![PyPi version](https://pypip.in/v/gitver/badge.png?)](https://crate.io/packages/gitver/)
-[![PyPi downloads](https://pypip.in/d/gitver/badge.png?)](https://crate.io/packages/gitver/)
+[![PyPi version](https://img.shields.io/pypi/v/gitver.svg)](https://crate.io/packages/gitver/)
+[![PyPi downloads](https://img.shields.io/pypi/dm/gitver.svg)](https://crate.io/packages/gitver/)
 [![Project Stats](https://ohloh.net/p/gitver/widgets/project_thin_badge.gif)](https://ohloh.net/projects/gitver)
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/manuelbua/gitver/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
 [![Flattr this git repo](http://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/submit/auto?user_id=manuelbua&url=https://github.com/manuelbua/gitver&title=gitver&language=&tags=github&category=software)


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20gitver))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `gitver`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.